### PR TITLE
Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Migme JavaScript SDK. Throws data to the [Migme API](http://docs.migme.apiary.io
 [![Codeship](https://img.shields.io/codeship/5e7f47c0-bfe9-0132-39f9-7eb09717a41c.svg)](https://codeship.com/projects/73070)
 [![Travis CI](https://img.shields.io/travis/migme/beachball.svg)](https://travis-ci.org/migme/beachball)
 [![JavaScript Standard Style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
-[![npm](https://img.shields.io/npm/v/migme.svg)](https://www.npmjs.com/package/migme)
-[![npm](https://img.shields.io/npm/dm/migme.svg)](https://www.npmjs.com/package/migme)
+[![npm](https://img.shields.io/npm/v/migme-beachball.svg)](https://www.npmjs.com/package/migme-beachball)
+[![npm](https://img.shields.io/npm/dm/migme-beachball.svg)](https://www.npmjs.com/package/migme-beachball)
 [![GitHub Releases](https://img.shields.io/github/downloads/migme/beachball/latest/total.svg)](https://github.com/migme/beachball/releases/latest)
 
 ![Beachball Migbot](https://cdn.rawgit.com/mixstix/5eb0fe3bea4e87ea5034/raw/fbf873d7d1b3c845e9e0f9613690489203479fcc/beachball.svg "Beachball Migbot")
@@ -16,13 +16,13 @@ Migme JavaScript SDK. Throws data to the [Migme API](http://docs.migme.apiary.io
 
 ### NPM
 ```bash
-npm install migme
+npm install migme-beachball
 ```
 
 ### CDN
 Replace `${VERSION}` with a released version number.
 ```html
-<script src="https://cdn.rawgit.com/migme/beachball/releases/download/${VERSION}/migme.min.js"></script>
+<script src="https://cdn.rawgit.com/migme/beachball/releases/download/${VERSION}/migme-beachball.min.js"></script>
 ```
 
 ## Usage
@@ -30,20 +30,20 @@ Replace `${VERSION}` with a released version number.
 ### Loading
 ```js
 // ES6
-import Migme from 'migme'
+import Beachball from 'migme-beachball'
 
 // CommonJS
-var Migme = require('migme')
+var Beachball = require('migme-beachball')
 
 // AMD
-define(['migme'], function (Migme) {
+define(['migme-beachball'], function (Beachball) {
   // ...
 })
 ```
 
 ### Initialization
 ```
-const client = new Migme({
+const client = new Beachball({
   // options
 })
 ```

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ Migme JavaScript SDK. Throws data to the [Migme API](http://docs.migme.apiary.io
 ![Beachball Migbot](https://cdn.rawgit.com/mixstix/5eb0fe3bea4e87ea5034/raw/fbf873d7d1b3c845e9e0f9613690489203479fcc/beachball.svg "Beachball Migbot")
 
 ## Installation
+
+### NPM
 ```bash
-npm install
-npm test    # Test only
-grunt build # Build only
-grunt       # Test, then build
+npm install migme
 ```
 
-## CDN
+### CDN
 Replace `${VERSION}` with a released version number.
 ```html
 <script src="https://cdn.rawgit.com/migme/beachball/releases/download/${VERSION}/migme.min.js"></script>
@@ -47,4 +46,12 @@ define(['migme'], function (Migme) {
 const client = new Migme({
   // options
 })
+```
+
+### Development
+```bash
+npm install # Install dependencies
+npm test    # Test only
+grunt build # Build only
+grunt       # Test, then build
 ```

--- a/grunt/babel.js
+++ b/grunt/babel.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   dist: {
     files: {
-      '<%= app.dist %>/migme.js': '<%= app.src %>/migme.js'
+      '<%= app.dist %>/<%= pkg.name %>.js': '<%= pkg.main %>'
     }
   }
 }

--- a/grunt/browserify.js
+++ b/grunt/browserify.js
@@ -2,7 +2,7 @@ module.exports = {
    options: {
     browserifyOptions: {
        debug: true,
-       standalone: 'Migme'
+       standalone: 'Beachball'
     },
     transform: [
       ['babelify', {
@@ -12,7 +12,7 @@ module.exports = {
   },
   bundle: {
     files: {
-      '<%= app.dist %>/migme.min.js': '<%= app.src %>/migme.js'
+      '<%= app.dist %>/<%= pkg.name %>.min.js': '<%= pkg.main %>'
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "migme",
+  "name": "migme-beachball",
   "version": "1.0.3",
-  "description": "Migme JavaScript SDK.",
-  "main": "src/migme.js",
+  "description": "Migme JavaScript SDK",
+  "main": "src/index.js",
   "scripts": {
     "test": "standard && grunt test",
     "codecov": "cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Session from './lib/Session'
 import API from './lib/API'
 
-export default class Migme {
+export default class Beachball {
   constructor ({
     client_id = '',
     redirect_uri = '',

--- a/test/spec/migme.spec.js
+++ b/test/spec/migme.spec.js
@@ -1,38 +1,38 @@
 /* global beforeEach describe expect it */
 'use strict'
-import Migme from '../../src/migme'
+import Beachball from '../..'
 import API from '../../src/lib/API'
 import Session from '../../src/lib/Session'
 
-describe('Migme', () => {
-  let migme
+describe('Beachball', () => {
+  let beachball
   const client_id = '309f818242abae8fdd1b'
   const access_token = 'TESTING'
 
   beforeEach(() => {
-    migme = new Migme({
+    beachball = new Beachball({
       client_id: client_id,
       access_token: access_token
     })
   })
 
   it('should be instantiated', () => {
-    expect(migme).to.exist
-    expect(migme).to.be.an.instanceof(Migme)
+    expect(beachball).to.exist
+    expect(beachball).to.be.an.instanceof(Beachball)
   })
 
   it('should expose Session', () => {
-    expect(migme.Session).to.exist
-    expect(migme.Session).to.be.an.instanceof(Session)
+    expect(beachball.Session).to.exist
+    expect(beachball.Session).to.be.an.instanceof(Session)
   })
 
   it('should expose API', () => {
-    expect(migme.API).to.exist
-    expect(migme.API).to.be.an.instanceof(API)
+    expect(beachball.API).to.exist
+    expect(beachball.API).to.be.an.instanceof(API)
   })
 
   it('should expose configuration', () => {
-    expect(migme).to.contain.all.keys([
+    expect(beachball).to.contain.all.keys([
       'client_id',
       'access_token',
       'baseUrl'
@@ -40,6 +40,6 @@ describe('Migme', () => {
   })
 
   it('should work without options', () => {
-    expect(() => new Migme()).not.to.throw(TypeError)
+    expect(() => new Beachball()).not.to.throw(TypeError)
   })
 })


### PR DESCRIPTION
Changing the library to export as Beachball rather than Migme. Once this goes live we can unpublish npm:migme from the registry to avoid (future) confusion and collisions.